### PR TITLE
[WIP] close() is not closing all fds

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,7 +342,11 @@ function deserializeHeader (buf) {
 // TODO: what if the new data is shorter than the old data? things will break!
 function writeStringToStorage (string, storage, cb) {
   var buf = Buffer.from(string, 'utf8')
-  storage.write(0, buf, cb)
+  storage.write(0, buf, function (err) {
+    storage.close(function () {
+      cb(err)
+    })
+  })
 }
 
 function readStringFromStorage (storage, cb) {
@@ -352,7 +356,9 @@ function readStringFromStorage (storage, cb) {
     storage.read(0, len, function (err, buf) {
       if (err) return cb(err)
       var str = buf.toString()
-      cb(null, str)
+      storage.close(function () {
+        cb(null, str)
+      })
     })
   })
 }

--- a/index.js
+++ b/index.js
@@ -76,11 +76,12 @@ Multifeed.prototype.close = function (cb) {
       })
     }
 
-    var feeds = values(self._feeds)
+    var feeds = values(self._feeds).concat(self._fake)
 
     function next (n) {
       if (n >= feeds.length) {
         self._feeds = []
+        self.fake = undefined
         return done()
       }
       feeds[n].close(function (err) {
@@ -193,7 +194,7 @@ Multifeed.prototype.replicate = function (opts) {
       })
     })
   }
-  
+
   function addMissingKeysLocked (keys, cb) {
     var pending = 0
     debug('[REPLICATION] recv\'d ' + keys.length + ' keys')

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "hypercore": "^6.18.1",
     "random-access-memory": "^2.4.0",
+    "rimraf": "^2.6.3",
     "standard": "~10.0.0",
     "tape": "~4.6.2",
     "tmp": "0.0.33"

--- a/test/basic.js
+++ b/test/basic.js
@@ -204,3 +204,14 @@ test('close', function (t) {
     })
   })
 })
+
+test('close empty multifeed', function (t) {
+  var storage = tmp()
+  var multi = multifeed(hypercore, storage, { valueEncoding: 'json' })
+
+  multi.close(function () {
+    t.deepEquals(multi.feeds(), [], 'no feeds present')
+    t.equals(multi.closed, true)
+    t.end()
+  })
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,6 +3,7 @@ var hypercore = require('hypercore')
 var multifeed = require('..')
 var ram = require('random-access-memory')
 var tmp = require('tmp').tmpNameSync
+var rimraf = require('rimraf')
 
 test('no feeds', function (t) {
   var multi = multifeed(hypercore, ram, { valueEncoding: 'json' })
@@ -200,18 +201,10 @@ test('close', function (t) {
     multi.close(function () {
       t.deepEquals(multi.feeds(), [], 'no feeds present')
       t.equals(multi.closed, true)
-      t.end()
+      rimraf(storage, function (err) {
+        t.error(err, 'Deleted folder without error')
+        t.end()
+      })
     })
-  })
-})
-
-test('close empty multifeed', function (t) {
-  var storage = tmp()
-  var multi = multifeed(hypercore, storage, { valueEncoding: 'json' })
-
-  multi.close(function () {
-    t.deepEquals(multi.feeds(), [], 'no feeds present')
-    t.equals(multi.closed, true)
-    t.end()
   })
 })


### PR DESCRIPTION
Tests on Windows surface an error where file descriptors are not being cleaned up.

Using `rimraf` after close on Windows is throwing an `EPERM` error. I have tracked this down to file descriptors not being closed. I haven't found a way of testing that file descriptors are open/closed - I tried using https://github.com/ronomon/opened but it didn't detect the open file descriptors.

This first step also closes the fake feed. TODO:

- [ ] close localname
