### PR TITLE
Feature/replication api

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,20 +125,40 @@ With [npm](https://npmjs.org/) installed, run
 $ npm install multifeed
 ```
 
-## Hacks
+## Replication Policies
 
-1. `hypercore-protocol` requires the first feed exchanged to be common between
-   replicating peers. This prevents two strangers from exchanging sets of
-   hypercores. A "fake" hypercore with a hardcoded public key is included in the
-   code to bootstrap the replication process. I discarded the private key, but
-   even if I didn't, it doesn't let me do anything nefarious. You could patch
-   this with your own key of choice.
-2. `hypercore-protocol` requires all feed keys be known upfront: only discovery
-   keys are exchanged (`discoveryKey = hash(key)`), so this module wraps the
-   hypercore replication duplex stream in a secondary duplex stream that
-   exchanges feed public keys upfront before moving on to the hypercore
-   replication mechanism.
+You can control which feeds get replicated by providing a policy object:
 
+```js
+
+var randomReplication = {
+  init: function(multifeed) {
+    // called on multifeed.ready
+    // use it for initalization.
+  },
+  have: function(local, share) {
+    // called on peer connection
+    // select which feeds to share
+    share(local.keys, {
+      random: local.keys.map(function() { return Math.random() - 0.5 })
+    })
+  },
+  want: function(remote, request) {
+    // called when remote peer's
+    // share list is available.
+    // remote.keys is always available
+    // remote contains also all custom props sent by remote.
+    var keys = remote.keys.filter(function(k, i){
+        return remote.random[i] > 0.5
+    })
+    request(keys)
+  }
+}
+
+var multi = multifeed(hypercore, './db', { valueEncoding: 'json' })
+multi.use(randomReplication)
+
+```
 ## See Also
 
 - [multifeed-index](https://github.com/noffle/multifeed-index)

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ Multifeed.prototype.close = function (cb) {
       })
     }
 
-    var feeds = values(self._feeds).concat(self._fake)
+    var feeds = values(self._feeds)
 
     function next (n) {
       if (n >= feeds.length) {
@@ -190,7 +190,7 @@ Multifeed.prototype.replicate = function (opts) {
         if (typeof plug.want !== 'function') return callPlug(i + 1, ctx)
 
         // give each plug a fresh reference to avoid peeking/postmodifications
-        plug.want(clone(ctx), function(keys) {
+        plug.want.bind(self)(clone(ctx), function(keys) {
           let n = clone(m)
           n.keys = keys
           callPlug(i + 1, n)
@@ -235,7 +235,7 @@ Multifeed.prototype.replicate = function (opts) {
           if (typeof plug.have !== 'function') return callPlug(i + 1, ctx)
 
           // give each plug a fresh reference to avoid peeking/postmodifications
-          plug.have(clone(ctx), function(keys, extras){
+          plug.have.bind(self)(clone(ctx), function(keys, extras){
             extras = extras || {}
             extras.keys = keys
             callPlug(i + 1, extras)

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "author": "Stephen Whitmore <sww@eight.net>",
   "version": "3.0.3",
   "repository": {
-    "url": "git://github.com/noffle/multifeed.git"
+    "url": "git://github.com/telamon/multifeed.git"
   },
   "homepage": "https://github.com/noffle/multifeed",
-  "bugs": "https://github.com/noffle/multifeed/issues",
+  "bugs": {
+    "url": "https://github.com/telamon/multifeed/issues"
+  },
   "main": "index.js",
   "scripts": {
     "test": "tape test/*.js",
@@ -31,5 +33,8 @@
     "through2": "^3.0.0",
     "tmp": "0.0.33"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "directories": {
+    "test": "test"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,10 @@
   "author": "Stephen Whitmore <sww@eight.net>",
   "version": "3.0.3",
   "repository": {
-    "url": "git://github.com/telamon/multifeed.git"
+    "url": "git://github.com/noffle/multifeed.git"
   },
   "homepage": "https://github.com/noffle/multifeed",
-  "bugs": {
-    "url": "https://github.com/telamon/multifeed/issues"
-  },
+  "bugs": "https://github.com/noffle/multifeed/issues",
   "main": "index.js",
   "scripts": {
     "test": "tape test/*.js",

--- a/test/replication-api.js
+++ b/test/replication-api.js
@@ -1,0 +1,115 @@
+var test = require('tape')
+var hypercore = require('hypercore')
+var ram = require('random-access-memory')
+var multifeed = require('../index')
+
+var bindStorage = function(subpath) {
+  return function(p) {
+    return ram(subpath + '/' + p)
+  }
+}
+
+test('Key exchange API', function(t){
+  t.plan(26)
+  var multi = multifeed(hypercore, bindStorage("first/"), { valueEncoding: 'json' })
+  var m2 = multifeed(hypercore, bindStorage("second/"), { valueEncoding: 'json' })
+  // A policy that only replicates feeds relevant to cats
+  // This policy shares everything but accepts only feeds tagged as 'cat'
+  var CatPolicy = {
+    have: function(local, share) {
+      t.ok(local.keys instanceof Array, "Param 'local' should be an array of localy available feeds")
+      t.ok(typeof share === 'function', "Param 'share' should be a function")
+
+      // 'Marketing phase' extract zeroth entry for all feeds an attach it
+      // to the feed-exchange
+      extractEntries(this.feeds(), function(entries) {
+        // Share all feeds including the sounds they make.
+        share(local.keys, {
+          says: entries.map(function(e) { return e.says })
+        })
+      })
+    },
+    want: function(remote, request) {
+      t.ok(remote.keys instanceof Array, "Param 'remote' should be an array of remotely available feeds")
+      t.ok(typeof request === 'function', "Param 'request' should be a function")
+      // Ok let's request only keys relevant to our logic.
+      var keys = remote.keys.filter(function(k, i){
+        return remote.says[i] === 'meow'
+      })
+      request(keys)
+    }
+  }
+
+  // let both multifeeds use the same policy
+  multi.use(CatPolicy)
+  m2.use(CatPolicy)
+
+  var replicateAndVerify = function(err) {
+    t.error(err)
+    t.equal(multi.feeds().length, 3)
+    t.equal(m2.feeds().length, 3)
+    // Verify that both catfeeds and the original dog-feed is present.
+    extractEntries(multi.feeds(), function(ent1) {
+      t.equal(ent1.filter(function(i) { return i.says === 'meow'}).length, 2, 'Should contain two cats')
+      t.equal(ent1.filter(function(i) { return i.says === 'squeek'}).length, 0, 'Should not contain any mice')
+      t.equal(ent1.filter(function(i) { return i.says === 'woof'}).length, 1, 'Should contain a dog')
+
+      // Verify that both catfeeds and the original rat-feed is present.
+      extractEntries(m2.feeds(), function(ent2) {
+        t.equal(ent2.filter(function(i) { return i.says === 'meow'}).length, 2, 'Should contain two cats')
+        t.equal(ent2.filter(function(i) { return i.says === 'woof'}).length, 0, 'Should not contain any dogs')
+        t.equal(ent2.filter(function(i) { return i.says === 'squeek'}).length, 1, 'Should contain a rat')
+        t.end()
+      })
+    })
+  }
+
+  // Initialize a cat feed on the first multifeed
+  multi.writer('a1',function(err, catFeed){
+    t.error(err)
+    // Append a cat-log
+    catFeed.append({says: 'meow', name: 'billy'}, function(err){
+      t.error(err)
+      // Initialize a dog feed on the first multifeed
+      multi.writer('a2', function(err, dogFeed) {
+        t.error(err)
+        // Append a dog-log
+        dogFeed.append({says: 'woof', name: 'rupert'}, function(err) {
+          t.error(err)
+          // Initialize another cat feed on the second multifeed
+          m2.writer('b1', function(err, cat2Feed) {
+            t.error(err)
+            // Append cat-log
+            cat2Feed.append({says: 'meow', name: 'amy'}, function(err) {
+              t.error(err)
+              // And lastly a rat feed on the second multifeed.
+              m2.writer('b2', function(err, ratFeed) {
+                t.error(err)
+                ratFeed.append({says: 'squeek', name: 'engelbrecht'}, function(err){
+                  t.error(err)
+                  t.ok(true, "Test data setup ok")
+                  // Replicating
+                  var r = multi.replicate()
+                  r.pipe(m2.replicate()).pipe(r)
+                    .once('end', replicateAndVerify)
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+function extractEntries(feeds, cb) {
+  var entries = []
+  var f = function (i) {
+    if (typeof feeds[i] === 'undefined') return cb(entries)
+    feeds[i].get(0, function(err, entry){
+      entries.push(entry)
+      f(i+1)
+    })
+  }
+  f(0)
+}


### PR DESCRIPTION
Hey!
This is the second feature I have in stock for multifeed (mentioned it earlier in Issue #2 )

It formalizes and exposes the feed-exchange to applications in order to let an application attach it's own metadata and control which feeds it want's to share and receive.

Example policies: 
```

var StaleFeedPolicy = {
  have: function(local, share) {
    share(local.keys, {
      lastActivity: extractLastEntryTimestamp(local.keys) // => [Date, Date, Date]
    })
  },
  want: function(remote, request) {
    var keys = remote.keys.filter(function(key, i){
      return remote.lastActivity[i] < 1000*60*60*24*7 // Accept if within 7 days
    })
    request(keys)
  }
}

var FeedTypePolicy = {
  have: function(local, share) {
    share(local.keys, {
      feedTypes: extractTypeFromFeeds(local.keys), // => ['chat', 'images', 'chat']
      sfw: extractSafeFlag(local.keys) // => [true, true, false]
    })
  },
  want: function(remote, request) {
    var keys = remote.keys.filter(function(key, i){
      // Accept only safe-for work chat feeds.
      return remote.feedTypes[i] == 'chat' && remote.sfw[i]
    })
    request(keys)
  }
}

multifeed.use(StaleFeedPolicy)
multifeed.use(FeedTypePolicy)
// Now, multifeed only accepts safe for work chat feeds that has entries
// within the past week.
// But all feeds are still available for replication to peers with different preferences.
```

I'm a little short on words today, hope the above examples explains the intention of the feature.
Will gladly receive feedback on the policy/adapter design as this was thrown together as a proof of concept. 

Maybe it's more useful to split it up as 2 separate types of plugins?  `multifeed.useShareProvider(...)` and `multifeed.useReceiveFilter(...)`