### PR TITLE
get feed using either feed pubkey or localname

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ Multifeed.prototype.feeds = function () {
 
 Multifeed.prototype.feed = function (key) {
   if (Buffer.isBuffer(key)) key = key.toString('hex')
-  if (typeof key === 'string') return this._feedKeyToFeed[key]
+  if (typeof key === 'string') return this._feedKeyToFeed[key] || this._feeds[key] || null
   else return null
 }
 


### PR DESCRIPTION
Small enhancement, now we can call `core.feed('local')` rather than having to use the feed `pubKey`. Useful for outstanding PR on peerfs: https://github.com/karissa/peerfs/pull/2