### PR TITLE
ensure feed.key is only called after feed is ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,8 +302,8 @@ Multifeed.prototype.replicate = function (opts) {
           return
         }
         debug(self._id + ' [REPLICATION] succeeded in creating new local hypercore, key=' + key.toString('hex'))
-        self._addFeed(feed, String(numFeeds))
         feed.ready(function () {
+          self._addFeed(feed, String(numFeeds))
           if (!--pending) cb()
         })
       }


### PR DESCRIPTION
been toying with inserting hyperdrive into multifeed, this is a snag that crops up, in function`addMissingKeysLocked`, `_addFeed` is called before the feed is ready, so it bombs out with:

```
  this._feedKeyToFeed[feed.key.toString('hex')] = feed
                               ^

TypeError: Cannot read property 'toString' of null
    at Multifeed._addFeed (/home/kyphae/Projects/cobox-core/node_modules/multifeed/index.js:67:32)
    at /home/kyphae/Projects/cobox-core/node_modules/multifeed/index.js:305:14
    at Array.forEach (<anonymous>)
    at addMissingKeysLocked (/home/kyphae/Projects/cobox-core/node_modules/multifeed/index.js:287:14)
    at /home/kyphae/Projects/cobox-core/node_modules/multifeed/index.js:274:9
    at call (/home/kyphae/Projects/cobox-core/node_modules/mutexify/index.js:6:5)
    at processTicksAndRejections (internal/process/next_tick.js:74:9)
```

 This resolves it.