### PR TITLE
Bugfix: Fixed racing condition in multifeed#close()

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function Multifeed (hypercore, storage, opts) {
 
   this.writerLock = mutexify()
 
+  this._close = readyify(_close.bind(this), true)
   this.closed = false
 
   // random-access-storage wrapper that wraps all hypercores in a directory
@@ -93,9 +94,13 @@ Multifeed.prototype.ready = function (cb) {
 }
 
 Multifeed.prototype.close = function (cb) {
-  var self = this
   if (typeof cb !== 'function') cb = function noop () {}
+  return this._close(cb)
+}
 
+function _close (cb) {
+  var self = this
+  console.log('CLOSE CALLDED')
   this.writerLock(function (release) {
     function done (err) {
       release(function () {

--- a/index.js
+++ b/index.js
@@ -100,7 +100,6 @@ Multifeed.prototype.close = function (cb) {
 
 function _close (cb) {
   var self = this
-  console.log('CLOSE CALLDED')
   this.writerLock(function (release) {
     function done (err) {
       release(function () {

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ Multifeed.prototype.ready = function (cb) {
 
 Multifeed.prototype.close = function (cb) {
   var self = this
+  if (typeof cb !== 'function') cb = function noop () {}
 
   this.writerLock(function (release) {
     function done (err) {

--- a/ready.js
+++ b/ready.js
@@ -1,13 +1,24 @@
-module.exports = function (work) {
+module.exports = function (work, noauto) {
   var ready = false
   var fns = []
-  process.nextTick(function () {
-    work(function () {
-      ready = true
-      fns.forEach(process.nextTick)
+
+  var startWork = function () {
+    process.nextTick(function () {
+      work(function () {
+        ready = true
+        fns.forEach(process.nextTick)
+      })
     })
-  })
+  }
+
+  if (!noauto) startWork() // default behaviour
+
   return function (fn) {
+    if (noauto) { // start on first invocation
+      noauto = false
+      startWork()
+    }
+
     if (!ready) fns.push(fn)
     else process.nextTick(fn)
   }

--- a/test/regression.js
+++ b/test/regression.js
@@ -280,3 +280,27 @@ test('regression: MFs with different root keys cannot replicate', function (t) {
     })
   }
 })
+
+test('Calling close while closing should not throw errors', function (t) {
+  var multi = multifeed(hypercore, ram, { valueEncoding: 'json' })
+  multi.ready(function () {
+    multi.writer('default', function (err, wr) {
+      t.error(err)
+      wr.append(Buffer.from('some data'), function (err) {
+        t.error(err)
+        var p = 2
+        multi.close(function () {
+          t.ok('initial close finished')
+          t.equal(multi.closed, true)
+          if (!--p) t.end()
+        })
+        t.equal(multi.closed, false, 'Multi not *yet* closed')
+        multi.close(function () {
+          t.ok('second close finished')
+          t.equal(multi.closed, true)
+          if (!--p) t.end()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Steps to reproduce:

```
const multi = multifeed(...)
multi.close()
console.log(multi.closed) // => false
if (!multi.closed) multi.close()
```

Used to throw error:

```
< multifeed/index.js:121
<       feeds[n].close(function (err) {
<                ^
< TypeError: Cannot read property 'close' of undefined
<     at next (multifeed/index.js:121:16)
<     at multifeed/index.js:127:5
<     at call (multifeed/node_modules/mutexify/index.js:6:5)
<     at process._tickCallback (internal/process/next_tick.js:61:11)
```