### PR TITLE
Fix unhandled error

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var mutexify = require('mutexify')
 var through = require('through2')
 var debug = require('debug')('multifeed')
 var multiplexer = require('./mux')
+var version = require('./package.json').version
 
 // Key-less constant hypercore to bootstrap hypercore-protocol replication.
 var defaultEncryptionKey = new Buffer('bee80ff3a4ee5e727dc44197cb9d25bf8f19d50b0f3ad2984cfe5b7d14e75de7', 'hex')
@@ -17,7 +18,7 @@ module.exports = Multifeed
 function Multifeed (hypercore, storage, opts) {
   if (!(this instanceof Multifeed)) return new Multifeed(hypercore, storage, opts)
   this._id = (opts||{})._id || Math.floor(Math.random() * 1000).toString(16)  // for debugging
-  debug(this._id, 'multifeed @ ' + require(path.join(__dirname,'package.json')).version)
+  debug(this._id, 'multifeed @ ' + version)
   this._feeds = {}
   this._feedKeyToFeed = {}
   this._streams = []

--- a/mux.js
+++ b/mux.js
@@ -136,7 +136,6 @@ Multiplexer.prototype.ready = function(cb) {
 Multiplexer.prototype._finalize = function(err) {
   if (err) {
     debug(this._id + ' [REPLICATION] destroyed due to', err)
-    this.emit('error', err)
     this.stream.destroy(err)
   } else {
     debug(this._id + ' [REPLICATION] finalized', err)


### PR DESCRIPTION
merge #38 before this.

An error in the multiplexer was emitting an error event on the multiplexer instance. There is no way to handle this error - only `mux.stream` is returned from `replicate()` and there is no `mux.on('error')` in the `replicate()` method. This causes an unhandled error in Node, so things just break on error.

I don't think we need to emit errors on the multiplexer instance, because the error is emitted on the stream returned from the `replicate()` function which is handled in https://github.com/kappa-db/multifeed/blob/master/mux.js#L140 `this.stream.destroy(err)`, so error handling is done via the stream not the multiplexer instance.
