### PR TITLE
allow custom keypair to be passed to `multi.writer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ have locally, and choose which of the remote feeds they'd like to download in
 exchange. Right now, the replication mechanism defauls to sharing all local
 feeds and downloading all remote feeds.
 
+Small module that manages multiple hypercores: feeds you create locally are
+writeable, others' are readonly. Replicating with another multifeed peers
+exchanges the content of all of the hypercores.
+
 ## Usage
 
 ```js
@@ -74,7 +78,7 @@ Valid `opts` include:
 - `opts.encryptionKey` (string): optional encryption key to use during replication. If not provided, a default insecure key will be used.
 - `opts.hypercore`: constructor of a hypercore implementation. `hypercore@8.x.x` is used from npm if not provided.
 
-### multi.writer([name, ]cb)
+### multi.writer([name], [keypair], cb)
 
 If no `name` is given, a new local writeable feed is created and returned via
 `cb`.
@@ -89,6 +93,8 @@ var content = multi.writer('content')  // created if doesn't exist
 
 main === multi.writer('main')          // => true
 ```
+
+Optionally, a `keypair` object can be passed, with a custom keypair for the new writer.  This should have properies `keypair.publicKey` and `keypair.secretKey` both of which should be buffers.
 
 ### var feeds = multi.feeds()
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ have locally, and choose which of the remote feeds they'd like to download in
 exchange. Right now, the replication mechanism defauls to sharing all local
 feeds and downloading all remote feeds.
 
-Small module that manages multiple hypercores: feeds you create locally are
-writeable, others' are readonly. Replicating with another multifeed peers
-exchanges the content of all of the hypercores.
-
 ## Usage
 
 ```js
@@ -78,7 +74,7 @@ Valid `opts` include:
 - `opts.encryptionKey` (string): optional encryption key to use during replication. If not provided, a default insecure key will be used.
 - `opts.hypercore`: constructor of a hypercore implementation. `hypercore@8.x.x` is used from npm if not provided.
 
-### multi.writer([name], [keypair], cb)
+### multi.writer([name], [options], cb)
 
 If no `name` is given, a new local writeable feed is created and returned via
 `cb`.
@@ -94,7 +90,8 @@ var content = multi.writer('content')  // created if doesn't exist
 main === multi.writer('main')          // => true
 ```
 
-Optionally, a `keypair` object can be passed, with a custom keypair for the new writer.  This should have properies `keypair.publicKey` and `keypair.secretKey` both of which should be buffers.
+`options` is an optional object which may contain: 
+- `options.keypair` - an object with a custom keypair for the new writer.  This should have properties `keypair.publicKey` and `keypair.secretKey`, both of which should be buffers.
 
 ### var feeds = multi.feeds()
 

--- a/index.js
+++ b/index.js
@@ -174,17 +174,19 @@ Multifeed.prototype._loadFeeds = function (cb) {
   next(0)
 }
 
-Multifeed.prototype.writer = function (name, keypair, cb) {
+Multifeed.prototype.writer = function (name, opts, cb) {
   if (typeof name === 'function' && !cb) {
     cb = name
     name = undefined
+    opts = {}
   }
-  if (typeof keypair === 'function' && !cb) {
-    cb = keypair
-    keypair = undefined
+  if (typeof opts === 'function' && !cb) {
+    cb = opts
+    opts = {}
   }
 
   var self = this
+  const keypair = opts.keypair
 
   this.ready(function () {
     // Short-circuit if already loaded

--- a/index.js
+++ b/index.js
@@ -174,11 +174,16 @@ Multifeed.prototype._loadFeeds = function (cb) {
   next(0)
 }
 
-Multifeed.prototype.writer = function (name, cb) {
+Multifeed.prototype.writer = function (name, keypair, cb) {
   if (typeof name === 'function' && !cb) {
     cb = name
     name = undefined
   }
+  if (typeof keypair === 'function' && !cb) {
+    cb = keypair
+    keypair = undefined
+  }
+
   var self = this
 
   this.ready(function () {
@@ -205,7 +210,9 @@ Multifeed.prototype.writer = function (name, cb) {
           return
         }
 
-        var feed = self._hypercore(storage, self._opts)
+        var feed = keypair
+          ? self._hypercore(storage, keypair.publicKey, Object.assign(self._opts, { secretKey: keypair.secretKey }))
+          : self._hypercore(storage, self._opts)
 
         feed.ready(function () {
           self._addFeed(feed, String(idx))

--- a/test/basic.js
+++ b/test/basic.js
@@ -308,3 +308,28 @@ test('replicate slow-to-open multifeeds', function (t) {
     t.equals(feedEvents2, 2)
   }
 })
+
+test('can create writer with custom keypair', function (t) {
+  t.plan(6)
+
+  const keypair = {
+    publicKey: Buffer.from('ce1f0639f6559736d5c98f9df9af111ff20f0980674297e4eb40cc8f00f1157e', 'hex'),
+    secretKey: Buffer.from('559f807745b2dd136ec96ebdffa81f0631bfc4bc6ee4bc86f5666b24db91665ace1f0639f6559736d5c98f9df9af111ff20f0980674297e4eb40cc8f00f1157e', 'hex')
+  }
+
+  var multi = multifeed(ram, { valueEncoding: 'json' })
+  multi.ready(function () {
+    multi.writer('moose', keypair, function (err, w) {
+      t.error(err, 'valid writer created')
+      t.same(w.key.toString('hex'), keypair.publicKey.toString('hex'), 'public keys match')
+      w.append('foo', function (err) {
+        t.error(err, 'no error when appending to feed')
+        w.get(0, function (err, data) {
+          t.error(err)
+          t.equals(data.toString(), 'foo')
+          t.deepEquals(multi.feeds(), [w])
+        })
+      })
+    })
+  })
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -310,7 +310,7 @@ test('replicate slow-to-open multifeeds', function (t) {
 })
 
 test('can create writer with custom keypair', function (t) {
-  t.plan(6)
+  t.plan(7)
 
   const keypair = {
     publicKey: Buffer.from('ce1f0639f6559736d5c98f9df9af111ff20f0980674297e4eb40cc8f00f1157e', 'hex'),
@@ -322,6 +322,7 @@ test('can create writer with custom keypair', function (t) {
     multi.writer('moose', { keypair }, function (err, w) {
       t.error(err, 'valid writer created')
       t.same(w.key.toString('hex'), keypair.publicKey.toString('hex'), 'public keys match')
+      t.same(w.secretKey.toString('hex'), keypair.secretKey.toString('hex'), 'secret keys match')
       w.append('foo', function (err) {
         t.error(err, 'no error when appending to feed')
         w.get(0, function (err, data) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -319,7 +319,7 @@ test('can create writer with custom keypair', function (t) {
 
   var multi = multifeed(ram, { valueEncoding: 'json' })
   multi.ready(function () {
-    multi.writer('moose', keypair, function (err, w) {
+    multi.writer('moose', { keypair }, function (err, w) {
       t.error(err, 'valid writer created')
       t.same(w.key.toString('hex'), keypair.publicKey.toString('hex'), 'public keys match')
       w.append('foo', function (err) {


### PR DESCRIPTION

This PR allows a custom keypair to be passed to `multi.writer`.  It is an optional adittional argument and is not an API breaking change.  The keypair is given as an object containing properties `secretKey` and `publicKey`, which should be buffers, and these are passed to the new hypercore instance.

The reason we want this:

We have a project where we are creating multiple writers, for each peer, and we would like to use key derivation such that the feeds use 'sub-keypairs' from a single master keypair, meaning only one keypair needs to be backed up.  Corestore 4 actually already has a kind of key derivation built in, but using it currently breaks a bunch of other things we are depending on.

Note that in order for this to be useful, we would probably also want to add it as an optional argument in `kappa-core`'s `core.writer` and pass it through. 

Let me know what you think.  Another option would be implement optional key derivation in this module, so all local writers could be generated deterministically from a single master key.

--Peg