### PR TITLE
fix replication with custom keypairs, and add a test

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ Multifeed.prototype.writer = function (name, opts, cb) {
         }
 
         var feed = keypair
-          ? self._hypercore(storage, keypair.publicKey, Object.assign(self._opts, { secretKey: keypair.secretKey }))
+          ? self._hypercore(storage, keypair.publicKey, Object.assign({}, self._opts, { secretKey: keypair.secretKey }))
           : self._hypercore(storage, self._opts)
 
         feed.ready(function () {


### PR DESCRIPTION
This fixes a bug introduced in the last keypair pull request, where the previous secret key was being assigned to the next hypercore in opts, causing keys not to match and replication to fail.