### PR TITLE
ensure opts from writer is used to generate hypercore

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,8 +212,9 @@ Multifeed.prototype.writer = function (name, opts, cb) {
         }
 
         var feed = keypair
-          ? self._hypercore(storage, keypair.publicKey, Object.assign({}, self._opts, { secretKey: keypair.secretKey }))
-          : self._hypercore(storage, self._opts)
+          ? self._hypercore(storage, keypair.publicKey, Object.assign({}, self._opts, opts, { secretKey: keypair.secretKey }))
+          : self._hypercore(storage, Object.assign(self._opts, opts))
+
         feed.on('error', function (err) {
           self.emit('error', err)
         })


### PR DESCRIPTION
Enables per-hypercore opts to be used over default set by multifeed instance. We need this in kappa-drive for an update to hyperdrive, see here:

https://gitlab.com/coboxcoop/kappa-drive/-/merge_requests/4/diffs#a77b15c0d64cf6111e025645e562faf8ccabb9d7_427_427

We're using multifeed's writer function to generate feeds, then creating a trie and hyperdrive out of those returned feeds. This custom opts allows us to create a trie with `{ valueEncoding: 'binary' }`, which is different to the other's feeds encodings.