### PR TITLE
allow replicate() to accept an existing hypercore-protocol instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Create an encrypted duplex stream for replication.
 
 Ensure that `isInitiator` to `true` to one side, and `false` on the other. This is necessary for setting up the encryption mechanism.
 
+`isInitiator` may also be a hypercore-protocol instance.
+
 Works just like hypercore, except *all* local hypercores are exchanged between
 replication endpoints.
 

--- a/mux.js
+++ b/mux.js
@@ -35,16 +35,22 @@ function Multiplexer (isInitiator, key, opts) {
   self._activeFeedStreams = {}
 
   var onFirstKey = true
-  var stream = this.stream = new Protocol(isInitiator, Object.assign({}, opts, {
-    ondiscoverykey: function (key) {
-      if (onFirstKey) {
-        onFirstKey = false
-        if (!self.stream.remoteVerified(key)) {
-          self._finalize(new Error('Exchange key did not match remote'))
-        }
+  if (Protocol.isProtocolStream(isInitiator)) {
+    var stream = this.stream = isInitiator
+    stream.on('discovery-key', ondiscoverykey)
+  } else {
+    var stream = this.stream = new Protocol(isInitiator, Object.assign({}, opts, {
+      ondiscoverykey
+    }))
+  }
+  function ondiscoverykey (key) {
+    if (onFirstKey) {
+      onFirstKey = false
+      if (!self.stream.remoteVerified(key)) {
+        self._finalize(new Error('Exchange key did not match remote'))
       }
     }
-  }))
+  }
 
   this._handshakeExt = this.stream.registerExtension(EXT_HANDSHAKE, {
     onmessage: onHandshake,

--- a/test/existing-protocol.js
+++ b/test/existing-protocol.js
@@ -1,0 +1,133 @@
+var test = require('tape')
+var crypto = require('hypercore-crypto')
+var Protocol = require('hypercore-protocol')
+var multifeed = require('..')
+var ram = require('random-access-memory')
+var ral = require('random-access-latency')
+var tmp = require('tmp').tmpNameSync
+var rimraf = require('rimraf')
+
+test('replicate from existing protocols', function (t) {
+  t.plan(26)
+
+  var m1 = multifeed(ram, { valueEncoding: 'json' })
+  var m2 = multifeed(ram, { valueEncoding: 'json' })
+
+  var feedEvents1 = 0
+  var feedEvents2 = 0
+  m1.on('feed', function (feed, name) {
+    t.equals(name, String(feedEvents1))
+    feedEvents1++
+  })
+  m2.on('feed', function (feed, name) {
+    t.equals(name, String(feedEvents2))
+    feedEvents2++
+  })
+
+  function setup (m, buf, cb) {
+    m.writer(function (err, w) {
+      t.error(err)
+      w.append(buf, function (err) {
+        t.error(err)
+        w.get(0, function (err, data) {
+          t.error(err)
+          t.equals(data, buf)
+          t.deepEquals(m.feeds(), [w])
+          cb()
+        })
+      })
+    })
+  }
+
+  setup(m1, 'foo', function () {
+    setup(m2, 'bar', function () {
+      var p1 = new Protocol(true)
+      var p2 = new Protocol(false)
+      var r1 = m1.replicate(p1)
+      var r2 = m2.replicate(p2)
+      r1.pipe(r2).pipe(r1)
+        .once('end', check)
+      r1.once('remote-feeds', function () {
+        t.ok(true, 'got r1 "remote-feeds" event')
+        t.equals(m1.feeds().length, 2, 'm1 feeds length is 2')
+      })
+      r2.once('remote-feeds', function () {
+        t.ok(true, 'got r2 "remote-feeds" event')
+        t.equals(m2.feeds().length, 2, 'm2 feeds length is 2')
+      })
+    })
+  })
+
+  function check () {
+    t.equals(m1.feeds().length, 2)
+    t.equals(m2.feeds().length, 2)
+    m1.feeds()[1].get(0, function (err, data) {
+      t.error(err)
+      t.equals(data, 'bar')
+    })
+    m2.feeds()[1].get(0, function (err, data) {
+      t.error(err)
+      t.equals(data, 'foo')
+    })
+    t.equals(feedEvents1, 2)
+    t.equals(feedEvents2, 2)
+  }
+})
+
+test('live replicate from existing protocols', function (t) {
+  t.plan(22)
+
+  var m1 = multifeed(ram, { valueEncoding: 'json' })
+  var m2 = multifeed(ram, { valueEncoding: 'json' })
+
+  var feedEvents1 = 0
+  var feedEvents2 = 0
+  m1.on('feed', function (feed, name) {
+    t.equals(name, String(feedEvents1))
+    feedEvents1++
+  })
+  m2.on('feed', function (feed, name) {
+    t.equals(name, String(feedEvents2))
+    feedEvents2++
+  })
+
+  function setup (m, buf, cb) {
+    m.writer(function (err, w) {
+      t.error(err)
+      w.append(buf, function (err) {
+        t.error(err)
+        w.get(0, function (err, data) {
+          t.error(err)
+          t.equals(data, buf)
+          t.deepEquals(m.feeds(), [w])
+          cb()
+        })
+      })
+    })
+  }
+
+  setup(m1, 'foo', function () {
+    setup(m2, 'bar', function () {
+      var p1 = new Protocol(true)
+      var p2 = new Protocol(false)
+      var r = m1.replicate(p1, {live:true})
+      r.pipe(m2.replicate(p2, {live:true})).pipe(r)
+      setTimeout(check, 1000)
+    })
+  })
+
+  function check () {
+    t.equals(m1.feeds().length, 2)
+    t.equals(m2.feeds().length, 2)
+    m1.feeds()[1].get(0, function (err, data) {
+      t.error(err)
+      t.equals(data, 'bar')
+    })
+    m2.feeds()[1].get(0, function (err, data) {
+      t.error(err)
+      t.equals(data, 'foo')
+    })
+    t.equals(feedEvents1, 2)
+    t.equals(feedEvents2, 2)
+  }
+})


### PR DESCRIPTION
This patch aligns multifeed's replicate method with hypercore's replicate(), where it's possible to take over replication from an existing hypercore-protocol instance. This way we can support schemes where there is some verification process over extension messages before replication begins.