### PR TITLE
Fix memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,12 +299,14 @@ Multifeed.prototype.replicate = function (isInitiator, opts) {
       mux.removeListener('manifest', onManifest)
       mux.removeListener('replicate', onReplicate)
       mux.stream.removeListener('end', cleanup)
+      mux.stream.removeListener('close', cleanup)
       mux.stream.removeListener('error', cleanup)
       mux.stream.finalize()
       self._streams.splice(self._streams.indexOf(mux), 1)
       debug('[REPLICATION] Client connection destroyed', err)
     }
     mux.stream.once('end', cleanup)
+    mux.stream.once('close', cleanup)
     mux.stream.once('error', cleanup)
   })
 

--- a/index.js
+++ b/index.js
@@ -118,6 +118,9 @@ function _close (cb) {
         self._feeds = []
         self._feedKeyToFeed = {}
         self._root = undefined
+        self._streams.forEach((mux) => {
+          mux._finalize()
+        })
         return done()
       }
       feeds[n].close(function (err) {

--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ function _close (cb) {
     function next (n) {
       if (n >= feeds.length) {
         self._feeds = []
+        self._feedKeyToFeed = {}
         self._root = undefined
         return done()
       }


### PR DESCRIPTION
A memory leak has been causing issues for the desktop and cli cabal clients and eventually causing the client to crash. This is my attempt to fix the issue.

## Replicating the Problem (pun intended)

I ran the following script in an attempt to see where the memory was building up while simulating peers replicating (normally via something like `hyperswarm` for cabal) and then closing hence simulating a disconnect.

`mem-leak.js`

```js
const multifeed = require('.')
const ram = require('random-access-memory')
const pump = require('pump')

const mf = multifeed(ram, { valueEncoding: 'json' })

const isLive = !!process.argv[2]

mf.writer('local', async (err, w) => {
  if (err) throw err

  // Update us on total number of feeds
  mf.on('feed', () => {
    console.log('mf.feeds().length', mf.feeds().length)
  })

  for (let i = 0; i < 61; i++) {
    await addMultifeed(mf)
  }

  // Ensure mf isnt garbage collected
  setInterval(() => {
    console.log('mf.feeds().length', mf.feeds().length)
  }, 10 * 1000)

  // Hold process open
  process.stdin.pipe(process.stdout)
})

function addMultifeed (mf) {
  return new Promise((resolve, reject) => {
    const mf2 = multifeed(ram, { valueEncoding: 'json' })
    mf2.writer('local', (err, w) => {
      if (err) throw err

      let mfReplication = mf.replicate(true, { live: isLive, download: false })
      let mf2Replication = mf2.replicate(false, { live: isLive, download: false })

      w.once('peer-open', (peer) => {
        console.log('peer open')
        mf2.close(resolve)
      })

      pump(mfReplication, mf2Replication, mfReplication, (err) => {
        if (err) {
          console.log('endes', err)
        }
      })
    })
  })
}
```

I ran the script using `--inspect` and chrome to take heap snapshots. On master it showed 2015 instances of `Feed` from only 62 `Multifeed`s being created (and sticking around).  When I ran it with `live` replication enabled (like so `node --inspect mem-leak.js 1`) the snapshot showed 3845 instances of `Feed` per 62 `Multifeed`s.

## Fixes (so far)

I found two fixes so far:

1. Clear `Multifeed`'s `_feedKeyToFeed` on `close()`  
    The `._feeds` array was cleared in `close()` but not the object for converting keys to feeds (`._feedKeyToFeed`). So the feeds were never GC'd. This made a big improvement bringing the snapshot to 63 instances of `Feed` (which makes sense because there are still 62 instances of `Multifeed` that aren't collected). With `live` enabled, it is still 3845 instances of `Feed` per 62 `Multifeed`s unfortunately.
2. Call `_finalize()` on all of `Multifeed`'s `stream`s on `close()`  
    This maintains the 63 `Feed`s for non-`live` replication but causes the `Feed` count for the `live` enabled snapshot to drop to 63! I'm guessing this helps clean up some of the stream references that linger with `live` enabled.

These results caused my heap sizes to go from `1089MB` (live: `2105MB`) to `46MB` (live: `47MB`). And all tests pass for me.

## More to Come

This is a WIP as there is still lingering `Multifeed` instances that should be GC'd. My best guess is this is due to references in the `Multiplexer` class that are holding on to them because 122 instances remain in the snapshot for all tests above.

Some of the last bit of cleanup that is possible might be due to my test script holding to references in a way that I didn't think of. I also assume there is a more elegant solution as I do not fully grok the replication method `multifeed` uses. So feel free to suggest / make improvements!