### PR TITLE
Bump to latest versions of hypercore and hypercore-protocol.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-- '8'
 - '10'
+- '12'
+- '14'
 os:
 - windows
 - osx

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "keywords": [],
   "dependencies": {
     "debug": "^4.1.0",
-    "hypercore": "^8.3.0",
-    "hypercore-protocol": "^7.7.1",
+    "hypercore": "^9.6.0",
+    "hypercore-protocol": "^8.0.7",
     "inherits": "^2.0.3",
     "mutexify": "^1.2.0",
     "once": "^1.4.0",


### PR DESCRIPTION
@cblgh and I have been experimenting with `kappa-core` in a web browser context over here: https://github.com/cblgh/caballo/

I discovered that when trying to use a browserfied `kappa-core`, an error was thrown which appears to derive from an old version of hypercore-protocol after following the stacktrace:

```
 ncaught TypeError: Path must be a string. Received undefined
    assertPath index.js:29
    dirname index.js:294
    path index.js:43
    load index.js:21
    [245]</</< index.js:1
    [245]</< bundle.js:42087
    [245]< bundle.js:42087
    o _prelude.js:1
    o _prelude.js:1
    [230]</</< handshake-state.js:1
    [230]</< bundle.js:38026
    [230]< bundle.js:38026
    o _prelude.js:1
    o _prelude.js:1
    [232]< index.js:1
    o _prelude.js:1
    o _prelude.js:1
    [234]</</< index.js:1
    [234]</< bundle.js:38396
    [234]< bundle.js:38396
    o _prelude.js:1
    o _prelude.js:1
    [236]</</< handshake.js:1
    [236]</< bundle.js:38806
    [236]< bundle.js:38806
    o _prelude.js:1
    o _prelude.js:1
    [235]</</< index.js:1
    [235]</< bundle.js:38707
    [235]< bundle.js:38707
    o _prelude.js:1
    o _prelude.js:1
    [224]< index.js:1
    o _prelude.js:1
    o _prelude.js:1
    [325]< replicate.js:1
    o _prelude.js:1
    o _prelude.js:1
    [322]</</< index.js:21
    [322]</< bundle.js:53414
    [322]< bundle.js:53414
    o _prelude.js:1
    o _prelude.js:1
    [319]</</< index.js:1
    [319]</< bundle.js:51329
    [319]< bundle.js:51329
    o _prelude.js:1
    o _prelude.js:1
    [277]< index.js:3
    o _prelude.js:1
    o _prelude.js:1
    [1]</</< index.js:13
    [1]</< bundle.js:169
    [1]< bundle.js:169
    o _prelude.js:1
    r _prelude.js:1
    <anonymous> _prelude.js:1
index.js:29
```
When overriding the versions of `hypercore` and `hypercore-protocol` this error disappears and `kappa-core` and `kappa-view` work in a browser tab.

The tests pass with these bumped versions, and our little experiment also works. Please let me know if there are any more robust ways I can do user testing to see if bumping these versions introduces any bugs.

